### PR TITLE
Fix issue #18: Add mass scaling engine for superelements

### DIFF
--- a/.github/workflows/build_doc.yml
+++ b/.github/workflows/build_doc.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Checkout the latest release tag
         run: |
-          git checkout `git tag | grep fedem- | tail -1`
+          git checkout `git tag -l --sort=version:refname 'fedem-*' | tail -1`
           git submodule update
 
       - name: Configure for build

--- a/.github/workflows/build_fmu.yml
+++ b/.github/workflows/build_fmu.yml
@@ -93,8 +93,8 @@ jobs:
 
       - name: Get latest release tag
         run: |
-          git checkout `git tag | grep fmu- tail -1`
-          echo "MY_TAG=`git tag | grep fmu- tail -1`" >> $GITHUB_ENV
+          git checkout `git tag -l --sort=version:refname 'fmu-*' | tail -1`
+          echo "MY_TAG=`git tag -l --sort=version:refname 'fmu-*' | tail -1`" >> $GITHUB_ENV
           echo "MY_VER=`cat cfg/VERSION`" >> $GITHUB_ENV
 
       - name: Download artifacts

--- a/.github/workflows/build_solvers.yml
+++ b/.github/workflows/build_solvers.yml
@@ -36,8 +36,8 @@ jobs:
 
       - name: Checkout the latest release tag
         run: |
-          git checkout `git tag | grep fedem- | tail -1`
-          echo "MY_TAG=`git tag | grep fedem- | tail -1`" >> $GITHUB_ENV
+          git checkout `git tag -l --sort=version:refname 'fedem-*' | tail -1`
+          echo "MY_TAG=`git tag -l --sort=version:refname 'fedem-*' | tail -1`" >> $GITHUB_ENV
           echo "MY_VER=`cat cfg/VERSION`" >> $GITHUB_ENV
 
       - name: Configure main build

--- a/PythonAPI/doc/make.sh
+++ b/PythonAPI/doc/make.sh
@@ -17,7 +17,7 @@ else
   exit 1
 fi
 
-current=`git tag | tail -1`
+current=`git -l --sort=version:refname "fedem-*" | tail -1`
 ftpyver=`cat ../version.txt`
 buildno=`sed "s/^.*\.//" ../version.txt`
 version=`sed "1 s/\"//g;1 s/.*$/& (build $buildno)/" ../../fedem-foundation/src/Admin/version.h`

--- a/src/vpmCommon/supElTypeModule.f90
+++ b/src/vpmCommon/supElTypeModule.f90
@@ -144,6 +144,8 @@ module SupElTypeModule
      real(dp) :: dmpScl(2)  !< Current and previous scaling of mDmp0 and kDmp0
      integer  :: dmpSclIdx  !< Index to structural damping scaling function
 
+     real(dp) :: massScl(2) !< Current and previous mass scaling factors
+     integer  :: massSclIdx !< Index to mass scaling function
      real(dp) :: stifScl(2) !< Current and previous stiffness scaling factors
      integer  :: stifSclIdx !< Index to stiffness scaling function
 
@@ -356,6 +358,7 @@ contains
     write(io,3) 'mDmpFactor    =', sup%mDmpFactor
     write(io,3) 'kDmpFactor    =', sup%kDmpFactor
     write(io,*) 'dmpScale(id)  =', sup%dmpSclIdx
+    write(io,*) 'massScale(id) =', sup%massSclIdx
     write(io,*) 'stifScale(id) =', sup%stifSclIdx
     write(io,*) 'savePos       =', sup%savePos
     write(io,*) 'saveVar       =', sup%saveVar
@@ -666,8 +669,10 @@ contains
     sup%mDmp0 = 0.0_dp
     sup%kDmp0 = 0.0_dp
     sup%dmpScl = 1.0_dp
+    sup%massScl = 1.0_dp
     sup%stifScl = 1.0_dp
     sup%dmpSclIdx = 0
+    sup%massSclIdx = 0
     sup%stifSclIdx = 0
     sup%savePos = .false.
     sup%saveVar = .false.
@@ -1273,6 +1278,7 @@ module SupElNamelistModule
   integer :: recoveryFlag          !< Flag for enabling stress recovery
   integer :: BC(maxGenDofs_p)      !< Boundary conditions for component modes
   integer :: strDmpEngineId        !< Base ID for structural damping function
+  integer :: massEngineId          !< Base ID for mass scaling function
   integer :: stiffEngineId         !< Base ID for stiffness scaling function
 
   integer :: savePos    !< Flag indicating whether position should be saved
@@ -1307,7 +1313,7 @@ module SupElNamelistModule
        &            refTriad2Id, offset2, &
        &            refTriad3Id, offset3, &
        &            stressStiffFlag, massCorrFlag, recoveryFlag, &
-       &            stiffEngineId, stiffScale, massScale, &
+       &            stiffEngineId, massEngineId, stiffScale, massScale, &
        &            dragParams, slamParams, &
        &            strDmpEngineId, alpha1, alpha2, alpha3, alpha4, BC, &
        &            savePos, saveVar
@@ -1343,7 +1349,8 @@ contains
     stressStiffFlag=-1; massCorrFlag=-1; recoveryFlag=-1
     stiffScale=1.0_dp; massScale=1.0_dp; dragParams=0.0_dp; slamParams=0.0_dp
     alpha1=0.0_dp; alpha2=0.0_dp; alpha3=0.0_dp; alpha4=0.0_dp
-    stiffEngineId=0; strDmpEngineId=0; BC=1; savePos=0; saveVar=0
+    massEngineId=0; stiffEngineId=0; strDmpEngineId=0
+    BC=1; savePos=0; saveVar=0
 
     read(infp,nml=SUP_EL,iostat=stat)
 

--- a/src/vpmSolver/addInSysModule.f90
+++ b/src/vpmSolver/addInSysModule.f90
@@ -40,7 +40,7 @@ contains
   !> @param Rhs Right-hand-side force vector
   !>
   !> @details The Newton matrix is a linear combination of the mass-, damping-
-  !> and stiffness matrices, Nmat = scaleM*M  + scaleC*C + scaleK*K.
+  !> and stiffness matrices, Nmat = scaleM*M + scaleC*C + scaleK*K.
   !> If @a Rhs is provided, contributions due to prescribed motions,
   !> if any, will be added.
   !>
@@ -142,6 +142,7 @@ contains
     do i = 1, size(mech%sups)
 
        if ( reComputeSupMat .or. mech%sups(i)%stressStiffFlag(1) == 1 .or. &
+            abs(mech%sups(i)%massScl(1)-mech%sups(i)%massScl(2)) > eps_p .or. &
             abs(mech%sups(i)%stifScl(1)-mech%sups(i)%stifScl(2)) > eps_p ) then
 
           call BuildSupNewtonMat (newTanStiff, scaleM, scaleC, scaleK, &
@@ -353,7 +354,8 @@ contains
 
     do i = 1, size(mech%sups)
        if (associated(mech%sups(i)%Mmat)) then
-          call addInSupMat (mech%sups(i)%Mmat, Mmat, mech%sups(i), sam, ierr)
+          call addInSupMat (mech%sups(i)%Mmat, Mmat, mech%sups(i), sam, ierr, &
+               &            scale=mech%sups(i)%massScl(1))
           if (ierr < 0) goto 900
        end if
        if (associated(mech%sups(i)%Mamat)) then

--- a/src/vpmSolver/initiateFunctionTypeModule.f90
+++ b/src/vpmSolver/initiateFunctionTypeModule.f90
@@ -139,6 +139,7 @@ contains
     use FiDeviceFunctionInterface, only : FiDF_Open
     use FFaFilePathInterface     , only : ffa_checkPath
     use FFaCmdLineArgInterface   , only : ffa_cmdlinearg_getbool
+    use FFaCmdLineArgInterface   , only : ffa_cmdlinearg_getstring
     use FFaCmdLineArgInterface   , only : ffa_cmdlinearg_intValue
     use FFaMathExprInterface     , only : ffame_create
     use FFaUserFuncInterface     , only : ffauf_init, ffauf_getnopar
@@ -158,6 +159,7 @@ contains
     real(dp)           :: H3, T1, Ga, W0, dW, g, sfunc(3,max_embsw_p), ramp(2)
     real(dp), pointer  :: waveData(:,:), tmpW(:)
     character(len=128) :: err_msg
+    character(len=520) :: plugin
 
     type(RAOType), pointer :: RAOlist, tmp
 
@@ -184,6 +186,8 @@ contains
 #endif
        end if
     end if
+
+    call ffa_cmdlinearg_getstring ('plugin',plugin)
 
     !! Gravitation constant
     g = sqrt(sum(gravity*gravity))
@@ -512,7 +516,7 @@ contains
        case (USER_DEFINED_p)
 
           !! User-defined function (plug-in)
-          stat = ffauf_init(channel,expression)
+          stat = ffauf_init(plugin,channel,expression)
           if (stat < 0) then
              err = err - 1
              call reportError (error_p, &

--- a/src/vpmSolver/initiateUserdefElTypeModule.f90
+++ b/src/vpmSolver/initiateUserdefElTypeModule.f90
@@ -278,6 +278,7 @@ contains
 #endif
     use reportErrorModule      , only : getErrorFile
     use reportErrorModule      , only : reportError, debugFileOnly_p
+    use FFaCmdLineArgInterface , only : ffa_cmdlinearg_getstring
 
     real(dp)           , intent(in)    :: gravity(3)
     type(UserdefElType), intent(inout) :: elms(:)
@@ -286,13 +287,15 @@ contains
     !! Local variables
     integer            :: i, lpu
     character(ldesc_p) :: signature
+    character(len=520) :: plugin
 
     !! --- Logic section ---
 
     ierr = 0
     if (size(elms) < 1) return
 
-    call Fi_UDE_Init (gravity(1),signature,ierr)
+    call ffa_cmdlinearg_getstring ('plugin',plugin)
+    call Fi_UDE_Init (plugin,gravity(1),signature,ierr)
     if (ierr < 0) goto 900
 
     lpu = getErrorFile()


### PR DESCRIPTION
This fixes #18 which is the solver part of the openfedem/fedem-gui#44.
Also fixes a bug(?) in the corresponding stiffness scaling - it shouldn't apply on the gravity force (but the new mass-scaling will).

Notice that there is a small difference in how non-constant mass scaling is applied compared to corresponding stiffness scaling: Whereas the updated stiffness scaling factor also applies to the stiffness-proportional damping for that part, the non-constant mass scaling does _not_ affect the mass-proportional damping. This is mainly caused by implementational details and probably not a crucial issue. But important to be aware of of if someone uses both time-dependent mass scaling _and_ mass-proportional damping.