### PR TITLE
VTFx export from fedempy.fmm_solver

### DIFF
--- a/.github/workflows/run_test.yml
+++ b/.github/workflows/run_test.yml
@@ -43,7 +43,7 @@ jobs:
         run: cmake --build ./pFUnit3-build --target install
 
       - name: Install required python packages
-        run: pip install numpy pandas PyYAML
+        run: pip install numpy pandas progress PyYAML
 
       - name: Configure main build
         run: >

--- a/PythonAPI/requirements.txt
+++ b/PythonAPI/requirements.txt
@@ -4,3 +4,4 @@ python-dateutil==2.8.2
 pytz==2022.7.1
 six==1.16.0
 types-PyYAML==6.0.12.8
+progress==1.6

--- a/PythonAPI/src/fedempy/fmm_solver.py
+++ b/PythonAPI/src/fedempy/fmm_solver.py
@@ -10,17 +10,18 @@ which operates directly on fedem mechanism model files (`*.fmm`).
 
 This module relies on the following environment variables:
 
-| *FEDEM_REDUCER* = Full path to the Fedem reducer shared object library
-| *FEDEM_SOLVER* = Full path to the Fedem solver shared object library
 | *FEDEM_MDB* = Full path to the Fedem model database shared object library
-
-The first variable needs to be set only if FE model reduction
-is to be performed. The other two variables are mandatory.
+| *FEDEM_SOLVER* = Full path to the Fedem dynamics solver shared object library
+| *FEDEM_REDUCER* = Full path to the Fedem reducer shared object library
+| *VIS_EXPORTER* = Full path to the Fedem VTFx exporter shared object library
+The third variable needs to be set only if FE model reduction is to be performed.
+The fourth variable needs to be set only if a VTFx file is to be exported.
+The first two variables are mandatory.
 
 This module can also be launched directly, to run a specified model,
 using the syntax
 
-| ``python -m fedempy.fmm_solver -f mymodel.fmm [--reduce-fem] [--save-model]``
+| ``python -m fedempy.fmm_solver -f mymodel.fmm [--reduce-fem] [--save-model] [-v mymodel.vtfx]``
 
 This will then invoke the method :meth:`fmm_solver.FmmSolver.solve_all`
 on the specified model-file (`mymodel.fmm`). If you already have a directory
@@ -31,15 +32,17 @@ those files by launching this module without arguments, i.e.:
 """
 
 from argparse import ArgumentParser
+from ctypes import c_double
 from os import environ, getcwd, path
 
+from fedempy.exporter import Exporter
 from fedempy.fmm import FedemModel, FmType
 from fedempy.inverse import InverseSolver
 from fedempy.reducer import FedemReducer
 from fedempy.solver import FedemException, FedemSolver
 
 
-def _solver_options(solver, rdbdir=""):
+def _solver_options(solver, rdbdir="", time_start=None, base_id=None):
     """
     Sets up the standard solver command-line options,
     taking into account the *.fco, *.fop and *.fao files, if they exist.
@@ -49,6 +52,12 @@ def _solver_options(solver, rdbdir=""):
         option_file = solver + "." + ext
         if path.isfile(rdbdir + option_file):
             opts += ["-" + ext, option_file]
+
+    if time_start:  # Add dynamics solver start time
+        opts.append("-timeStart=" + str(time_start))
+
+    if base_id:  # Add flag for in-core von Mises stress array
+        opts.append("-partVMStress=2")
 
     return opts
 
@@ -139,7 +148,13 @@ class FmmSolver(FedemSolver):
         super().__init__(environ["FEDEM_SOLVER"], None, use_internal_state)
         self._model = FedemModel(environ["FEDEM_MDB"])
         self._reducer = None
+        self._vtfx = None
         self._func_map = {}
+        self._c_transf = None
+        self._c_deform = {}
+        self._c_stress = {}
+        self._prev_time = 0
+        self._time_incr = 0
 
         # Start the Fedem dynamics solver
         status = self.start(model_file, keep_old_res)
@@ -160,22 +175,31 @@ class FmmSolver(FedemSolver):
             chn += 1
             tag = self._model.fm_get_func_tag(chn)
 
-    def _reduce_fe_model(self):
+    def _reduce_fe_model(self, do_reduce):
         """
         Reduces all FE parts in the currently open model,
         which are not already redused.
+
+        Parameters
+        ----------
+        do_reduce : bool
+            Skip the FE part reduction if False
 
         Returns
         -------
         int
             Number of FE parts that was reduced, negative on error
         """
-        if self._reducer is None:
-            if "FEDEM_REDUCER" not in environ:
-                return 0
-            self._reducer = FedemReducer(environ["FEDEM_REDUCER"])
 
         num_reduced = 0
+        if not do_reduce:
+            return num_reduced
+
+        if self._reducer is None:
+            if "FEDEM_REDUCER" not in environ:
+                return num_reduced
+            self._reducer = FedemReducer(environ["FEDEM_REDUCER"])
+
         # Get list (of base Id) of the FE parts in the model
         fe_parts = self._model.fm_get_objects(FmType.FEPART)
         for base_id in fe_parts:
@@ -196,6 +220,89 @@ class FmmSolver(FedemSolver):
             print("#### FE model reduction done.", flush=True)
         return num_reduced
 
+    def _open_vtfx_exporter(self, vtfx_file, model_file):
+        """
+        Opens the VTFx file exporter and write the FE models to it.
+
+        Parameters
+        ----------
+        vtfx_file : str
+            Absolute path of the VTFx output file
+        model_file : str
+            Fedem model file name to derive the case name from
+
+        Returns
+        -------
+        list of int
+            Base ID of FE parts for which stress recovery will be performed
+        """
+
+        if vtfx_file is None:
+            return None
+
+        if "VIS_EXPORTER" not in environ:
+            print("  ** Environment variable VIS_EXPORTER not defined, no VTFx export.")
+            return None
+
+        # Get list (of base Id) of the FE parts in the model
+        # and the associated FE data files
+        base_ids = []
+        fem_parts = []
+        vis_parts = []
+        all_parts = self._model.fm_get_objects(FmType.FEPART)
+        for base_id in all_parts:
+            fem_file, recover = self._model.fm_get_femodel(base_id)
+            if recover == -1:  # Generic part with visualization file only
+                vis_parts.append(
+                    {
+                        "path": fem_file,
+                        "name": path.splitext(path.basename(fem_file))[0],
+                        "base_id": base_id,
+                    }
+                )
+            elif recover >= 0:  # This is an FE part
+                fem_parts.append(
+                    {
+                        "path": fem_file,
+                        "name": path.splitext(path.basename(fem_file))[0],
+                        "base_id": base_id,
+                        "recovery": recover > 0,
+                    }
+                )
+            if recover > 0:  # Stress recovery will be performed for this FE part
+                base_ids.append(base_id)
+
+        # Create the VTFx exporter object
+        self._vtfx = Exporter(
+            fem_parts,
+            vis_parts,
+            environ["VIS_EXPORTER"],
+            vtfx_file,
+            path.splitext(path.basename(model_file))[0],
+        )
+
+        return base_ids
+
+    def _init_result_buffers(self, base_ids):
+        """
+        Allocates state arrays to pass results to the VTFx exporter module.
+
+        Parameters
+        ----------
+        base_ids : list of int
+            Base ID of FE parts for which stress recovery will be performed
+
+        """
+        self._c_transf = (c_double * self.get_transformation_state_size())()
+        self._c_deform = {}
+        self._c_stress = {}
+        for bid in base_ids:
+            def_size = self.get_part_deformation_state_size(bid)
+            if def_size > 0:
+                str_size = self.get_part_stress_state_size(bid)
+                self._c_deform[bid] = (c_double * def_size)()
+                self._c_stress[bid] = (c_double * (str_size if str_size > 0 else 0))()
+
     def start(
         self,
         model_file,
@@ -206,6 +313,7 @@ class FmmSolver(FedemSolver):
         gauge_data=None,
         extf_input=None,
         time_start=None,
+        vtfx_file=None,
     ):
         """
         Starts a simulation on the specified model file.
@@ -230,6 +338,8 @@ class FmmSolver(FedemSolver):
             Initial external function values, for initial equilibrium iterations
         time_start : float, default=None
             Optional start time of simulation, override setting in model file
+        vtfx_file : str, default=None
+            Absolute path of the VTFx output file for visualization in GLview
 
         Returns
         -------
@@ -268,9 +378,12 @@ class FmmSolver(FedemSolver):
         print("     Total number of mechanism objects:", self._model.fm_count())
 
         # Check for FE model reduction
-        num_red = self._reduce_fe_model() if reduce_fem else 0
+        num_red = self._reduce_fe_model(reduce_fem)
         if num_red < 0:
             return error_exit(-98)
+
+        # Initialize the VTFx file exporter
+        base_ids = self._open_vtfx_exporter(vtfx_file, model_file)
 
         # Create the results database file structure
         # populated with the solver input files
@@ -288,19 +401,39 @@ class FmmSolver(FedemSolver):
             self.close_model(num_red > 0)
 
         # Start the dynamics solver
-        options = _solver_options("fedem_solver", rdbdir)
-        if time_start is not None:
-            options.append("-timeStart=" + str(time_start))
+        options = _solver_options("fedem_solver", rdbdir, time_start, base_ids)
         status = self.solver_init(options, None, state_data, gauge_data, extf_input)
         if status < 0:
             if not close_model:
                 self._model.fm_close(True)
             print(" *** Failed to start the dynamics solver.")
             _print_res(_get_resfile(rdbdir, "fedem_solver"))
+        elif base_ids is not None:
+            self._init_result_buffers(base_ids)
 
         return status
 
-    def close_model(self, save=False, remove_singletons=False):
+    def _export_step(self):
+        """
+        Exports results for current step to the VTFx file, if any.
+        """
+        if not self._vtfx or self.have_results() == 0:
+            return
+
+        self.save_transformation_state(self._c_transf)
+        for bid, deformation in self._c_deform.items():
+            self.save_part_state(bid, deformation, self._c_stress[bid])
+
+        # Find the (largest) time increment, for setting the animation frame rate
+        ctime = self.get_current_time()
+        delta = ctime - self._prev_time
+        self._prev_time = ctime
+        if delta > self._time_incr:
+            self._time_incr = delta
+
+        self._vtfx.do_step(ctime, self._c_transf, self._c_deform, self._c_stress)
+
+    def close_model(self, save=False, remove_singletons=False, fringe_max=-1):
         """
         Closes the currently open model.
 
@@ -310,6 +443,9 @@ class FmmSolver(FedemSolver):
             If True, the model file is updated based on current result files
         remove_singletons : bool, default=False
             If True, heap-allocated singelton objects are also released
+        fringe_max : float, default=-1
+            Max fringe range value for VTFx output.
+            If less than zero, the range will be set automatically.
 
         Returns
         -------
@@ -323,9 +459,20 @@ class FmmSolver(FedemSolver):
             status = True
 
         self._model.fm_close(not status or remove_singletons)
+
+        if self._vtfx:
+            self._vtfx.clean(self._time_incr, fmax=fringe_max)
+
         return status
 
-    def solve_all(self, model_file, save_model=True, reduce_fem=False):
+    def solve_all(
+        self,
+        model_file,
+        save_model=True,
+        reduce_fem=False,
+        vtfx_file=None,
+        fringe_max=-1,
+    ):
         """
         Starts and runs through a simulation on the specified model file.
 
@@ -339,6 +486,11 @@ class FmmSolver(FedemSolver):
             If True, and the model contains FE parts, they will be reduced
             before the solver is started, unless the reduced matrix files
             already exist
+        vtfx_file : str, default=None
+            Absolute path of the VTFx output file for visualization in GLview
+        fringe_max : float, default=-1
+            Max fringe range value for VTFx output.
+            If less than zero, the range will be set automatically.
 
         Returns
         -------
@@ -354,20 +506,20 @@ class FmmSolver(FedemSolver):
             return self.run_all(options) if options else 0
 
         print("\n#### Running dynamics solver on", model_file)
-        ierr = self.start(model_file, True, False, reduce_fem)
+        ierr = self.start(model_file, True, False, reduce_fem, vtfx_file=vtfx_file)
         if ierr < 0:
             print(f" *** Solver failed to start ({ierr}).")
             return ierr
 
         # Run through the entire time series
         while self.solve_next():
-            pass  # Dummy statement
+            self._export_step()
 
         if self.solver_done() == 0 and self.ierr.value == 0:
             print("     Time step loop OK, solver closed")
-            self.close_model(save_model)
+            self.close_model(save_model, False, fringe_max)
         else:
-            self.close_model(False, True)
+            self.close_model(False, True, fringe_max)
             print(" *** Dynamics solver failed", self.ierr.value)
 
         return self.ierr.value
@@ -426,13 +578,19 @@ class FmmInverse(FmmSolver, InverseSolver):
 if __name__ == "__main__":
     parser = ArgumentParser(description="Python Fedem Solver")
     parser.add_argument(
-        "-f", "--model-file", required=False, help="Fedem model file to open"
+        "-f", "--model-file", required=True, help="Fedem model file to open"
     )
     parser.add_argument(
         "-s", "--save-model", action="store_true", help="Save updated model file"
     )
     parser.add_argument(
         "-r", "--reduce-fem", action="store_true", help="Reduce model before solve"
+    )
+    parser.add_argument(
+        "-v", "--vtfx-file", help="Ceetron VTFx output file for visualization"
+    )
+    parser.add_argument(
+        "-m", "--fringe-max", type=float, default=-1, help="Max von Mises fringe value"
     )
     model = FmmSolver()
     model.solve_all(**vars(parser.parse_args()))

--- a/PythonAPI/src/fedempy/fmm_solver.py
+++ b/PythonAPI/src/fedempy/fmm_solver.py
@@ -39,7 +39,7 @@ from fedempy.exporter import Exporter
 from fedempy.fmm import FedemModel, FmType
 from fedempy.inverse import InverseSolver
 from fedempy.reducer import FedemReducer
-from fedempy.solver import FedemException, FedemSolver
+from fedempy.solver import FedemException, FedemProgressBar, FedemSolver
 
 
 def _solver_options(solver, rdbdir="", time_start=None, base_id=None):
@@ -512,8 +512,14 @@ class FmmSolver(FedemSolver):
             return ierr
 
         # Run through the entire time series
-        while self.solve_next():
-            self._export_step()
+        with FedemProgressBar(self) as pbar:
+            pbar.next()
+            while self.solve_next():
+                self._export_step()
+                pbar.next()
+            if self.ierr.value == 0:
+                self._export_step()
+                pbar.next()
 
         if self.solver_done() == 0 and self.ierr.value == 0:
             print("     Time step loop OK, solver closed")

--- a/PythonAPI/src/fedempy/reducer.py
+++ b/PythonAPI/src/fedempy/reducer.py
@@ -13,7 +13,6 @@ from ctypes import c_bool, c_char_p, c_int, cdll
 
 
 class FedemReducer:
-
     """
     This class mirrors the functionality of the Fedem FE part reducer library
     (libfedem_reducer_core.so on Linux, fedem_reducer_core.dll on Windows).
@@ -74,7 +73,7 @@ class FedemReducer:
         """
         This function initializes the command-line handler of the reducer.
 
-        See the Fedem R7.5 Users Guide, Appendix C.2 for a complete list of all
+        See the Fedem R8.0 Users Guide, Appendix C.2 for a complete list of all
         command-line arguments that may be specified and their default values.
 
         Parameters

--- a/PythonAPI/src/fedempy/solver.py
+++ b/PythonAPI/src/fedempy/solver.py
@@ -158,6 +158,7 @@ class FedemSolver:
         self._solver.solverInit.restype = c_int
         self._solver.restartFromState.restype = c_int
         self._solver.solveWindow.restype = c_bool
+        self._solver.haveResults.restype = c_int
         self._solver.getStateSize.restype = c_int
         self._solver.getTransformationStateSize.restype = c_int
         self._solver.getPartDeformationStateSize.restype = c_int
@@ -327,7 +328,7 @@ class FedemSolver:
         This method processes the input and sets up necessary data structures
         prior to the time integration loop. It also performs the license checks.
 
-        See the Fedem R7.5 Users Guide, Appendix C.3 for a complete list of all
+        See the Fedem R8.0 Users Guide, Appendix C.3 for a complete list of all
         command-line arguments that may be specified and their default values.
 
         If the argument fsi is None, the model is assumed defined in the file
@@ -492,6 +493,12 @@ class FedemSolver:
             outputs[:] = outputs_
 
         return outputs, not_done and success
+
+    def have_results(self):
+        """
+        Utility returning whether current time step have results to be saved.
+        """
+        return self._solver.haveResults()
 
     def get_state_size(self):
         """

--- a/src/SolutionMapper/CMakeLists.txt
+++ b/src/SolutionMapper/CMakeLists.txt
@@ -18,6 +18,9 @@ if ( USE_MEMPOOL )
   string ( APPEND CMAKE_CXX_FLAGS " -DFT_USE_MEMPOOL" )
 endif ( USE_MEMPOOL )
 
+# Need to use FFlLib classes in the FTK namespace
+string ( APPEND CMAKE_CXX_FLAGS " -DFF_NAMESPACE=FTK" )
+
 string ( APPEND CMAKE_CXX_FLAGS_DEBUG " -DFT_DEBUG=1" )
 
 

--- a/src/SolutionMapper/main.C
+++ b/src/SolutionMapper/main.C
@@ -15,7 +15,7 @@
 #include "FFlLib/FFlLinkHandler.H"
 #include "FFlLib/FFlIOAdaptors/FFlReaders.H"
 #include "FFlLib/FFlIOAdaptors/FFlFedemWriter.H"
-#include "FFlLib/FFlFEParts/FFlShellElementBase.H"
+#include "FFlLib/FFlFEParts/FFlShells.H"
 #include "FFlLib/FFlFEParts/FFlNode.H"
 #include "FFlLib/FFlElementBase.H"
 #include "FFaLib/FFaAlgebra/FFaMath.H"
@@ -29,6 +29,10 @@
 #include <fstream>
 #include <iomanip>
 #include <cstring>
+
+#ifdef FF_NAMESPACE
+using namespace FF_NAMESPACE;
+#endif
 
 extern void cmdLineArgInitStd(int argc, char** argv);
 extern void readOptionFilesStd(const char* program);

--- a/src/vpmCommon/vpmLinAlg/vpmLinAlgTests/CMakeLists.txt
+++ b/src/vpmCommon/vpmLinAlg/vpmLinAlgTests/CMakeLists.txt
@@ -14,13 +14,16 @@ message ( STATUS "INFORMATION : Processing unit ${UNIT_ID}" )
 # Avoid that the generated module files are moved to the common folder
 unset ( CMAKE_Fortran_MODULE_DIRECTORY )
 
+# Need to use FFlLib classes in the FTK namespace
+string ( APPEND CMAKE_CXX_FLAGS " -DFF_NAMESPACE=FTK" )
+
 add_library ( ${LIB_ID} testModels.C )
 add_library ( ${LIB_ID}_F90 generate_system.f90
                         ../../../vpmReducer/samReducerModule.f90
                         ../../../vpmReducer/rigidModule.f90
                         ../../../vpmReducer/wavgmModule.f90 )
 target_link_libraries ( ${LIB_ID} FFlLib )
-target_link_libraries ( ${LIB_ID}_F90 ${LIB_ID} vpmLinAlg )
+target_link_libraries ( ${LIB_ID}_F90 FFlLib_F ${LIB_ID} vpmLinAlg )
 
 if ( pFUnit_FOUND )
   # Add some unit tests using pFUnit (executed via ctest)

--- a/src/vpmCommon/vpmLinAlg/vpmLinAlgTests/testModels.C
+++ b/src/vpmCommon/vpmLinAlg/vpmLinAlgTests/testModels.C
@@ -26,11 +26,14 @@
 
 #include "FFlLib/FFlLinkHandler.H"
 #include "FFlLib/FFlFEParts/FFlNode.H"
-#include "FFlLib/FFlFEParts/FFlQUAD4.H"
-#include "FFlLib/FFlFEParts/FFlQUAD8.H"
+#include "FFlLib/FFlFEParts/FFlShells.H"
 #include "FFlLib/FFlFEParts/FFlRGD.H"
 #include "FFlLib/FFlFEParts/FFlPMAT.H"
 #include "FFlLib/FFlFEParts/FFlPTHICK.H"
+
+#ifdef FF_NAMESPACE
+using namespace FF_NAMESPACE;
+#endif
 
 
 /*!

--- a/src/vpmReducer/vpmReducerTests/CMakeLists.txt
+++ b/src/vpmReducer/vpmReducerTests/CMakeLists.txt
@@ -20,6 +20,9 @@ if ( USE_MEMPOOL )
   string ( APPEND CMAKE_CXX_FLAGS " -DFT_USE_MEMPOOL" )
 endif ( USE_MEMPOOL )
 
+# Need to use FFlLib classes in the FTK namespace
+string ( APPEND CMAKE_CXX_FLAGS " -DFF_NAMESPACE=FTK" )
+
 include_directories ( ${CMAKE_CURRENT_BINARY_DIR}/.. )
 
 add_library ( ${LIB_ID} smallReducer.f90 solveSupel.f90 )

--- a/src/vpmReducer/vpmReducerTests/testModels.C
+++ b/src/vpmReducer/vpmReducerTests/testModels.C
@@ -28,11 +28,9 @@
 
 #include "FFlLib/FFlLinkHandler.H"
 #include "FFlLib/FFlFEParts/FFlNode.H"
-#include "FFlLib/FFlFEParts/FFlBEAM2.H"
-#include "FFlLib/FFlFEParts/FFlTRI3.H"
-#include "FFlLib/FFlFEParts/FFlTRI6.H"
-#include "FFlLib/FFlFEParts/FFlQUAD4.H"
-#include "FFlLib/FFlFEParts/FFlQUAD8.H"
+#include "FFlLib/FFlFEParts/FFlBeams.H"
+#include "FFlLib/FFlFEParts/FFlShells.H"
+#include "FFlLib/FFlFEParts/FFlLoads.H"
 #include "FFlLib/FFlFEParts/FFlRGD.H"
 #include "FFlLib/FFlFEParts/FFlWAVGM.H"
 #include "FFlLib/FFlFEParts/FFlBUSH.H"
@@ -41,7 +39,10 @@
 #include "FFlLib/FFlFEParts/FFlPBEAMPIN.H"
 #include "FFlLib/FFlFEParts/FFlPTHICK.H"
 #include "FFlLib/FFlFEParts/FFlPMAT.H"
-#include "FFlLib/FFlFEParts/FFlCLOAD.H"
+
+#ifdef FF_NAMESPACE
+using namespace FF_NAMESPACE;
+#endif
 
 
 /*!
@@ -874,4 +875,11 @@ int createFEModel (int iPart, int nel, int nel2,
   }
 
   return 0;
+}
+
+
+//! \brief Releases the current FE model from memory.
+void clearFEModel ()
+{
+  ffl_setLink(NULL);
 }

--- a/src/vpmReducer/vpmReducerTests/testReducer.C
+++ b/src/vpmReducer/vpmReducerTests/testReducer.C
@@ -26,8 +26,6 @@
 #include "FFaLib/FFaCmdLineArg/FFaCmdLineArg.H"
 #include "FFaLib/FFaOS/FFaFortran.H"
 
-class FFlLinkHandler;
-
 //! \cond DO_NOT_DOCUMENT
 void cmdLineArgInit (int argc, char** argv);
 void redirectOutput2Ftn (int whichFile);
@@ -36,7 +34,7 @@ int createFEModel (int iPart, int nels, int nel2,
                    bool twoD, bool solve = true);
 extern "C" int ffl_loadPart (const std::string& linkFile);
 void releaseSingeltons (bool lastPart = true);
-void ffl_setLink (FFlLinkHandler*);
+void clearFEModel ();
 
 SUBROUTINE (solver,SOLVER) (const int&, const int*, double*, int& iret);
 SUBROUTINE (reducer,REDUCER) (int& iret);
@@ -184,7 +182,7 @@ int main (int argc, char** argv)
     F90_NAME(reducer,REDUCER) (ierr);
 
   // Erase the FE model
-  ffl_setLink(NULL);
+  clearFEModel();
 
   if (ierr || slv || ipart == 2)
   {

--- a/src/vpmSolver/controlTypeModule.f90
+++ b/src/vpmSolver/controlTypeModule.f90
@@ -41,8 +41,8 @@ module ControlTypeModule
 
      type(CtrlPrm), pointer :: input(:)  !< Control input parameters
      real(dp)     , pointer :: vreg(:)   !< The control state variables
-     integer      , pointer :: ivar(:)   !< Control variables for extra lines
      type(IdType) , pointer :: vregId(:) !< Id for the control line variables
+     integer      , pointer :: ivar(:)   !< Control variables for extra lines
      logical                :: saveVar   !< .true. if variables should be saved
 
      integer           :: mpireg(9)  !< Matrix of pointers into IREG
@@ -100,10 +100,11 @@ contains
        allocate(ctrl%input(0))
     end if
 
-    nullify(ctrl%ireg)
-    nullify(ctrl%rreg)
     nullify(ctrl%vreg)
     nullify(ctrl%vregId)
+    nullify(ctrl%ivar)
+    nullify(ctrl%ireg)
+    nullify(ctrl%rreg)
     nullify(ctrl%delay)
 #ifdef FT_HAS_EXTCTRL
     nullify(ctrl%extCtrlSys)
@@ -139,17 +140,17 @@ contains
     !! --- Logic section ---
 
     if (associated(ctrl%input)) deallocate(ctrl%input)
-    if (associated(ctrl%ireg))  deallocate(ctrl%ireg)
-    if (associated(ctrl%rreg))  deallocate(ctrl%rreg)
-    if (associated(ctrl%delay)) deallocate(ctrl%delay)
     if (associated(ctrl%vreg))  deallocate(ctrl%vreg)
-
     if (associated(ctrl%vregId)) then
        do i = 1, size(ctrl%vregId)
           call deallocateId (ctrl%vregId(i))
        end do
        deallocate(ctrl%vregId)
     end if
+    if (associated(ctrl%ivar))  deallocate(ctrl%ivar)
+    if (associated(ctrl%ireg))  deallocate(ctrl%ireg)
+    if (associated(ctrl%rreg))  deallocate(ctrl%rreg)
+    call reAllocate ('deallocateCtrl',ctrl%delay)
 
 #ifdef FT_HAS_EXTCTRL
     if (associated(ctrl%extCtrlSys)) then
@@ -160,7 +161,6 @@ contains
     end if
 #endif
 
-    call reAllocate ('deallocateCtrl',ctrl%delay)
     call nullifyCtrl (ctrl,.true.)
 
   end subroutine deallocateCtrl
@@ -752,9 +752,15 @@ contains
           write(io,*) 'size(input)  =', size(ctrl%input)
           write(io,*) 'size(mpireg) =', size(ctrl%mpireg)
           write(io,*) 'size(mprreg) =', size(ctrl%mprreg)
-          write(io,*) 'size(ireg)   =', size(ctrl%ireg)
-          write(io,*) 'size(rreg)   =', size(ctrl%rreg)
-          write(io,*) 'size(delay)  =', size(ctrl%delay)
+          if (associated(ctrl%ireg)) then
+             write(io,*) 'size(ireg)   =', size(ctrl%ireg)
+          end if
+          if (associated(ctrl%rreg)) then
+             write(io,*) 'size(rreg)   =', size(ctrl%rreg)
+          end if
+          if (associated(ctrl%delay)) then
+             write(io,*) 'size(delay)  =', size(ctrl%delay)
+          end if
 #ifdef FT_HAS_EXTCTRL
           if (associated(ctrl%extCtrlSys)) then
              write(io,*) 'size(extCtrlSys) =', size(ctrl%extCtrlSys)

--- a/src/vpmSolver/initiateJointTypeModule.f90
+++ b/src/vpmSolver/initiateJointTypeModule.f90
@@ -1001,7 +1001,9 @@ contains
        do j = 1, joints(i)%nJointDOFs
           ipl = joints(i)%jointDofs(j)%loadIdx
           ipr = joints(i)%jointDofs(j)%sysDOF
-          if (associated(mpreac) .and. ipr <= size(mpreac)) then
+          if (.not.associated(mpreac)) then
+             ipr = 0
+          else if (ipr <= size(mpreac)) then
              ipr = mpreac(ipr)
           else
              ipr = 0

--- a/src/vpmSolver/solverDriver.f90
+++ b/src/vpmSolver/solverDriver.f90
@@ -483,3 +483,13 @@ subroutine slv_savepart (iopS,bid,data,ndat,ierr)
   integer , intent(out) :: ierr    !< Error flag
   call savePartState (iopS,bid,data,ndat,ierr)
 end subroutine slv_savepart
+
+!===============================================================================
+!> @brief Checks whether current time step have results to be saved.
+!> @callgraph
+function slv_haveresults ()
+  use solverModule, only : haveResults
+  implicit none
+  integer :: slv_haveresults
+  slv_haveresults = haveResults()
+end function slv_haveresults

--- a/src/vpmSolver/solverDriver.f90
+++ b/src/vpmSolver/solverDriver.f90
@@ -182,16 +182,16 @@ subroutine slv_done (ierr)
 end subroutine slv_done
 
 !===============================================================================
-!> @brief Returns the time of current or next time increment.
+!> @brief Returns the physical time of a specified simulation state.
 !> @callgraph
-function slv_gettime (nextStep,ierr) result(time)
+function slv_gettime (tflag,ierr) result(time)
   use kindModule  , only : dp
   use solverModule, only : getTime
   implicit none
-  logical, intent(in)    :: nextStep !< If .true, return the time of next step
-  integer, intent(inout) :: ierr     !< Error flag
+  integer, intent(in)    :: tflag !< Indicates which step to return the time for
+  integer, intent(inout) :: ierr  !< Error flag
   real(dp) :: time
-  call getTime (time,nextStep,ierr)
+  call getTime (time,tflag,ierr)
 end function slv_gettime
 
 !===============================================================================

--- a/src/vpmSolver/solverInterface.C
+++ b/src/vpmSolver/solverInterface.C
@@ -150,6 +150,7 @@ DOUBLE_FUNCTION (slv_getfunction,SLV_GETFUNCTION) (int& ierr,
                                                    const int nchar);
 INTEGER_FUNCTION (slv_getfuncid,SLV_GETFUNCID) (const char* tag,
                                                 const int nchar);
+INTEGER_FUNCTION (slv_haveresults,SLV_HAVERESULTS) ();
 INTEGER_FUNCTION (slv_statesize,SLV_STATESIZE) (const int& posOnly);
 INTEGER_FUNCTION (slv_gagessize,SLV_GAGESSIZE) ();
 INTEGER_FUNCTION (slv_partsize,SLV_PARTSIZE) (const int& iop, const int& bid);
@@ -912,6 +913,12 @@ DLLexport(bool) solveWindow (const int nStep, int nInc, int nIn, int nOut,
   if (*ierr) releaseGlobalHeapObjects();
 
   return done == 0;
+}
+
+
+DLLexport(int) haveResults ()
+{
+  return F90_NAME(slv_haveresults,SLV_HAVERESULTS) ();
 }
 
 

--- a/src/vpmSolver/solverInterface.C
+++ b/src/vpmSolver/solverInterface.C
@@ -140,7 +140,7 @@ SUBROUTINE (slv_rhsvec,SLV_RHSVEC) (double* Rvec, const int& iop, int& ierr);
 INTEGER_FUNCTION (slv_geteqn,SLV_GETEQN) (const int& bid, int* meqn);
 INTEGER_FUNCTION (slv_getvar,SLV_GETVAR) (const int& bid, double* var);
 INTEGER_FUNCTION (slv_syssize,SLV_SYSSIZE) (const int& dofs);
-DOUBLE_FUNCTION (slv_gettime,SLV_GETTIME) (const int& nextStep, int& ierr);
+DOUBLE_FUNCTION (slv_gettime,SLV_GETTIME) (const int& tFlag, int& ierr);
 SUBROUTINE(slv_settime,SLV_SETTIME) (const double& nextTime, int& ierr);
 DOUBLE_FUNCTION (slv_getfunc,SLV_GETFUNC) (const int& uid, const double& x,
                                            int& ierr);
@@ -593,9 +593,8 @@ DLLexport(int) solverInit (int argc, char** argv, const char* cfsi,
   }
 
   // Initialization finished, check if we are doing a restart (iop = -3)
-  double startTime = 0.0;
   double currentTime = F90_NAME(slv_gettime,SLV_GETTIME) (0,ierr);
-  FFaCmdLineArg::instance()->getValue ("timeStart",startTime);
+  double startTime = F90_NAME(slv_gettime,SLV_GETTIME) (2,ierr);
   iop = currentTime > startTime ? -3 : 0;
   if (!cfsi || (stateData && ndat > 0))
     return 0;
@@ -729,9 +728,9 @@ DLLexport(void) solverClose ()
 }
 
 
-DLLexport(double) getTime (bool nextStep, int* ierr)
+DLLexport(double) getTime (int tFlag, int* ierr)
 {
-  return F90_NAME(slv_gettime,SLV_GETTIME) (nextStep,*ierr);
+  return F90_NAME(slv_gettime,SLV_GETTIME) (tFlag,*ierr);
 }
 
 

--- a/src/vpmSolver/solverInterface.h
+++ b/src/vpmSolver/solverInterface.h
@@ -112,6 +112,11 @@ extern "C" {
                    int nDat, double* stateData, int* ierr);
 
   /*!
+    \brief Returns whether current time step have results to be saved.
+  */
+  int haveResults();
+
+  /*!
     \brief Returns the required length of the state vector to be is used when
     restarting a simulation from an in-core array.
   */

--- a/src/vpmSolver/solverInterface.h
+++ b/src/vpmSolver/solverInterface.h
@@ -347,11 +347,15 @@ extern "C" {
   bool setExtFunc(int funcId, double value);
 
   /*!
-    \brief Returns current or next physical time of the simulation.
-    \param[in] nextStep If \e true, return next time, otherwise current
-    \param[out] ierr Error flag
+    \brief Returns the physical time of a time step.
+    \param[in] tFlag Flag indicating which time step to return the time for
+    - 0 : Return for current time step
+    - 1 : Return for next time step
+    - 2 : Return the start time of the simulation
+    - 3 : Return the stop time of the simulation
+    \param ierr Error flag, untouched unless \a tFlag = 1
   */
-  double getTime(bool nextStep, int* ierr);
+  double getTime(int tFlag, int* ierr);
 
   /*!
     \brief Sets the time increment size of the next time step.
@@ -361,17 +365,16 @@ extern "C" {
 
   /*!
     \brief Returns the current physical time of the simulation.
-    \param[out] ierr Always equal to zero
   */
-  inline double getCurrentTime(int* ierr) { return getTime(false,ierr); }
+  inline double getCurrentTime() { int ierr; return getTime(0,&ierr); }
 
   /*!
     \brief Returns the physical time of the next step of the simulation.
-    \param[out] ierr Equal to zero on a successful call, a non-zero value may
-    occur only if the time step size in the model is defined via a general
-    function that could not be evaluated.
+    \param ierr Untouched on a successful call,
+    decremented if the time step size in the model is defined via
+    a general function that could not be evaluated.
   */
-  inline double getNextTime(int* ierr) { return getTime(true,ierr); }
+  inline double getNextTime(int* ierr) { return getTime(1,ierr); }
 
   /*!
     \brief Evaluates a specified general function in the model.

--- a/src/vpmSolver/solverModule.f90
+++ b/src/vpmSolver/solverModule.f90
@@ -77,7 +77,7 @@ module solverModule
   public :: partStateVectorSize, savePartState
   public :: strainGagesSize, saveInitGageStrains
   public :: getSystemMatrix, getElementMatrix, getRhsVector, setRhsVector
-  public :: systemSize, objectEquations, objectStateVar
+  public :: systemSize, objectEquations, objectStateVar, haveResults
   public :: solverParameters, solveLinEqSystem
   public :: computeGageStrains, computeBeamForces, computeRelativeDistance
   public :: computeResponseVars, getJointSpringStiffness
@@ -1506,6 +1506,30 @@ contains
     solveDynamic = .not. isQuasiStatic(sys)
 
   end function solveDynamic
+
+
+  !!==========================================================================
+  !> @brief Returns whether current step have results to be saved.
+  !>
+  !> @callergraph
+  !>
+  !> @author Knut Morten Okstad
+  !>
+  !> @date 6 Dec 2024
+
+  integer function haveResults ()
+
+    !! --- Logic section ---
+
+    if (lRec /= 1 .and. lRec /= 3) then
+       haveResults = 1 ! Only transformation results (every time step)
+    else if (sys%time - lastRec < 1.0e-12_dp) then
+       haveResults = 2 ! This step have stress recovery results
+    else
+       haveResults = 0 ! No results for this time step
+    end if
+
+  end function haveResults
 
 
   !!============================================================================

--- a/src/vpmSolver/solverModule.f90
+++ b/src/vpmSolver/solverModule.f90
@@ -1533,13 +1533,17 @@ contains
 
 
   !!============================================================================
-  !> @brief Returns the simulation time of the current or next time step.
+  !> @brief Returns the physical time of a specified simulation state.
   !>
-  !> @param[out] time The simulation time returned
-  !> @param[in] nextStep If .true., return for next step, otherwise current step
-  !> @param ierr Error flag
+  !> @param[out] time The physical time value
+  !> @param[in] tflag Flag indicating which time step to return for
+  !> - 0 : Return for current time step
+  !> - 1 : Return for next time step
+  !> - 2 : Return the start time of the simulation
+  !> - 3 : Return the stop time of the simulation
+  !> @param ierr Error flag, untouched unless @a tflag = 1
   !>
-  !> @details This subroutine does not always work with @a nextStep = .true.
+  !> @details This subroutine does not always work with @a tflag = 1
   !> if cut-back is performed, as the time step size then might be decreased.
   !>
   !> @callgraph @callergraph
@@ -1548,21 +1552,26 @@ contains
   !>
   !> @date 5 Dec 2016
 
-  subroutine getTime (time,nextStep,ierr)
+  subroutine getTime (time,tflag,ierr)
 
     use TimeStepModule, only : getTimeStepSize
 
     real(dp), intent(out)   :: time
-    logical , intent(in)    :: nextStep
+    integer , intent(in)    :: tflag
     integer , intent(inout) :: ierr
 
     !! --- Logic section ---
 
-    if (nextStep) then
+    select case (tflag)
+    case (1)
        time = sys%time + getTimeStepSize(sys,sam,ctrl,1.0_dp,ierr)
-    else
+    case (2)
+       time = sys%tStart
+    case (3)
+       time = sys%tEnd
+    case default
        time = sys%time
-    end if
+    end select
 
   end subroutine getTime
 

--- a/src/vpmSolver/stressRecoveryModule.f90
+++ b/src/vpmSolver/stressRecoveryModule.f90
@@ -256,8 +256,12 @@ contains
     end if
 
     do i = 1, size(part)
-       if (part(i)%baseId == id .and. associated(part(i)%vms)) then
-          ndat = size(part(i)%vms)
+       if (part(i)%baseId == id) then
+          if (associated(part(i)%vms)) then
+             ndat = size(part(i)%vms)
+          else
+             ndat = -2
+          end if
           return
        end if
     end do
@@ -632,7 +636,7 @@ contains
           if (mod(sups(i)%rcy%recovery,2) == 1) then
              write(lpu,"()")
              call reportError (note_p,'Stress recovery is performed'// &
-                  &            ' for Part'//getId(sups(i)%id),'')
+                  &            ' for Part'//getId(sups(i)%id))
 
              nnod = part(irec)%sam%mpar(33)
              if (nnod > 0 .and. nnod < part(irec)%sam%nnod) then
@@ -704,6 +708,7 @@ contains
        end do
 
     end if
+    write(lpu,"(/)")
 
     return
 

--- a/src/vpmSolver/vpmSolverTests/testExternal.C
+++ b/src/vpmSolver/vpmSolverTests/testExternal.C
@@ -157,7 +157,7 @@ int main (int argc, char** argv)
     for (int funcId : fId)
       outputs.push_back(getFunc(funcId));
     if (vfy) os.precision(9);
-    printOut(os,false,getCurrentTime(&status),outputs.data(),fId.size());
+    printOut(os,false,getCurrentTime(),outputs.data(),fId.size());
   }
 
   // Write external function values to file
@@ -185,7 +185,7 @@ int main (int argc, char** argv)
     const int nStep = 100;
     outputs.resize(nOut*nStep);
     // Caution: We here assume the time step size in the model is constant
-    double t  = getCurrentTime(&status);
+    double t  = getCurrentTime();
     double dt = getNextTime(&status) - t;
 
     // Generate inputs

--- a/src/vpmSolver/vpmSolverTests/testInverse.C
+++ b/src/vpmSolver/vpmSolverTests/testInverse.C
@@ -141,7 +141,7 @@ int main (int argc, char** argv)
   {
     os.open("outputs.asc");
     os.precision(9);
-    os << getCurrentTime(&status);
+    os << getCurrentTime();
     for (int funcId : fId) os <<" "<< evalFunc(funcId);
     os << std::endl;
   }

--- a/src/vpmSolver/vpmSolverTests/testRestart.C
+++ b/src/vpmSolver/vpmSolverTests/testRestart.C
@@ -95,7 +95,7 @@ int main (int argc, char** argv)
   double* gages = NULL;
 
   // Caution: We here assume the time step size in the model is constant
-  double t  = getCurrentTime(&status);
+  double t  = getCurrentTime();
   double dt = getNextTime(&status) - t;
 
   // Invoke the dynamics solver for the time windows
@@ -132,8 +132,11 @@ int main (int argc, char** argv)
     status = solverInit(argc,argv,NULL,state,stateSize,gages,gagesSize);
     if (status) return status; // Simulation failed, aborting...
 
-    t  = getCurrentTime(&status);
-    dt = getNextTime(&status) - t;
+    if (!outputs.empty())
+    {
+      t  = getCurrentTime();
+      dt = getNextTime(&status) - t;
+    }
   }
   delete[] state;
   delete[] gages;

--- a/src/vpmSolver/vpmSolverTests/test_solver.C
+++ b/src/vpmSolver/vpmSolverTests/test_solver.C
@@ -131,16 +131,15 @@ TEST_P(Solve, SystemModel)
   const std::vector<double>& refVar = GetParam().refVar;
 
   // Lambda function for checking the response for current time step.
-  auto&& checkResponse = [baseId,refVar](size_t ip, int& status)
+  auto&& checkResponse = [baseId,refVar](size_t ip)
   {
     // Extract response at the specified object
     double var[3];
-    double t = getCurrentTime(&status);
     int nvar = getStateVar(baseId,var);
     EXPECT_GT(nvar,0);
 
     // Print response
-    std::cout <<"Time="<< t <<":";
+    std::cout <<"Time="<< getCurrentTime() <<":";
     for (int j = 0; j < nvar; j++)
       std::cout <<" V"<< 1+j <<"="<< var[j];
     std::cout << std::endl;
@@ -153,7 +152,7 @@ TEST_P(Solve, SystemModel)
   // Read input, preprocess the model and setup/solve the initial configuration
   int ierr = solverInit(args.size(),args.data());
   ASSERT_GE(ierr,0);
-  checkResponse(0,ierr);
+  checkResponse(0);
 
   if (!GetParam().linear)
   {
@@ -162,11 +161,11 @@ TEST_P(Solve, SystemModel)
     while (solveNext(&ierr))
     {
       ASSERT_EQ(ierr,0);
-      checkResponse(ipr,ierr);
+      checkResponse(ipr);
       ipr += 3;
     }
     ASSERT_EQ(ierr,0);
-    checkResponse(ipr,ierr);
+    checkResponse(ipr);
   }
 
   // Simulation finished, terminate by closing down external files, etc.
@@ -238,14 +237,13 @@ TEST(Solve, Prescribed)
 
     // Extract response at the specified triads, 25 and 17
     double var[6];
-    double t = getCurrentTime(&ierr);
     int nvar = getStateVar(25,var);
     int nva2 = getStateVar(17,var+nvar);
     ASSERT_EQ(nvar,3);
     ASSERT_EQ(nva2,3);
 
     // Print response
-    std::cout <<"Time="<< t <<":";
+    std::cout <<"Time="<< getCurrentTime() <<":";
     for (int j = 0; j < 6; j++)
       std::cout <<" V"<< 1+j <<"="<< var[j];
     std::cout << std::endl;

--- a/src/vpmStress/elStressModule.f90
+++ b/src/vpmStress/elStressModule.f90
@@ -470,7 +470,7 @@ contains
     Sg(6) = Sg(6) - Ey*Sg(1) + Ex*Sg(2)
 
     ! Transform to local coordinates
-    call DCOS30(T,Xg,Yg,Zg)
+    call DCOS30(T,Xg,Yg,Zg,BSEC(14))
     SN = matmul(T,Sg(1:3))
     SM = matmul(T,Sg(4:6))
 


### PR DESCRIPTION
This extends the `fedempy.fmm_solver` module with the option to export the response (part transformations + deformations and von Mises stresses as scalar) to a VTFx file while running the simulation. Will work only when you have the VTFXExporter shared library installed (not part of the openfedem project).

Also in this PR is a simple progress-bar in the console window when running the solver using fedempy. This is based on the python module [progress](https://pypi.org/project/progress/). Finally some minor bugfixes and a fixup to #24.