### PR TITLE
Fixup for commit b97268646e700ec1bc5dd40a1b2f72a53f4e4d23

### DIFF
--- a/PythonAPI/src/fedempy/fmm_solver.py
+++ b/PythonAPI/src/fedempy/fmm_solver.py
@@ -589,7 +589,14 @@ class FmmInverse(FmmSolver, InverseSolver):
         Option to not overwrite any existing res-file in the RDB directory
     """
 
-    def __init__(self, model_file, config, use_internal_state=False, keep_res=False):
+    def __init__(
+        self,
+        model_file,
+        config,
+        use_internal_state=False,
+        keep_res=False,
+        print_step=True,
+    ):
         """
         Constructor.
         Optionally starts the simulation, if a model file is specified.
@@ -598,7 +605,7 @@ class FmmInverse(FmmSolver, InverseSolver):
         FmmSolver.__init__(self, model_file, use_internal_state, keep_res)
 
         # Initialize the inverse solver
-        InverseSolver.__init__(self, self, config)
+        InverseSolver.__init__(self, self, config, print_step)
 
 
 if __name__ == "__main__":

--- a/PythonAPI/src/fedempy/inverse.py
+++ b/PythonAPI/src/fedempy/inverse.py
@@ -16,7 +16,7 @@ from numpy.linalg import inv, lstsq, solve
 
 from fedempy.enums import FmType
 from fedempy.log_conf import get_logger
-from fedempy.solver import FedemException, FedemSolver, FedemProgressBar
+from fedempy.solver import FedemException, FedemProgressBar, FedemSolver
 
 try:
     from scipy import linalg
@@ -66,9 +66,9 @@ class InverseSolver:
         The Fedem dynamics solver instance
     config : dictionary
         Inverse solver configuration
-    print_stepping : bool, default=False
+    print_stepping : bool
         If True, print some time stepping info.
-        Otherwise use progress bar only.
+        Otherwise use the progress bar only.
 
     Methods
     -------
@@ -1026,7 +1026,9 @@ class InverseSolver:
                 if self.modes_solver == 3 and have_sci_py:
                     f_vec = self._mode_load_scipy(self.solver, self.modes, do_print)
                 else:
-                    f_vec = self._mode_load(self.solver, self.modes, self.modes_solver, do_print)
+                    f_vec = self._mode_load(
+                        self.solver, self.modes, self.modes_solver, do_print
+                    )
                 if f_mat is None:
                     f_mat = f_vec
                 else:
@@ -1222,7 +1224,7 @@ class FedemRun(FedemSolver, InverseSolver):
         Content of yaml input file
     print_stepping : bool, default=False
         If True, print some time stepping info.
-        Otherwise use progress bar only.
+        Otherwise use the progress bar only.
     """
 
     def __init__(self, wrkdir, config, print_stepping=False):


### PR DESCRIPTION
The `InverseSolver()` constructor has no default value for the added print_stepping parameter.
Also resolve some isort and black formatting issues.